### PR TITLE
Fixed deprecated method and changed property to protected for the map…

### DIFF
--- a/src/Profile/OwnProfile/Converter/ProductConverter.php
+++ b/src/Profile/OwnProfile/Converter/ProductConverter.php
@@ -17,7 +17,7 @@ class ProductConverter extends ShopwareConverter
     /**
      * @var MappingServiceInterface
      */
-    private $mappingService;
+    protected $mappingService;
 
     /**
      * @var string
@@ -60,7 +60,7 @@ class ProductConverter extends ShopwareConverter
         /**
          * Gets the product uuid out of the mapping table or creates a new one
          */
-        $converted['id'] = $this->mappingService->createNewUuid(
+        $converted['id'] = $this->mappingService->getOrCreateMapping(
             $migrationContext->getConnection()->getId(),
             ProductDataSet::getEntity(),
             $data['id'],
@@ -105,7 +105,7 @@ class ProductConverter extends ShopwareConverter
          * If no tax rate is found, create a new one
          */
         if (empty($taxUuid)) {
-            $taxUuid = $this->mappingService->createNewUuid(
+            $taxUuid = $this->mappingService->getOrCreateMapping(
                 $this->connectionId,
                 DefaultEntities::TAX,
                 $data['id'],

--- a/src/Profile/OwnProfile/Converter/ProductConverter.php
+++ b/src/Profile/OwnProfile/Converter/ProductConverter.php
@@ -112,7 +112,7 @@ class ProductConverter extends ShopwareConverter
                 $data['id'],
                 $this->context
             );
-            $converted['id'] = $mapping['entityUuid'];
+            $taxUuid = $mapping['entityUuid'];
         }
 
         return [

--- a/src/Profile/OwnProfile/Converter/ProductConverter.php
+++ b/src/Profile/OwnProfile/Converter/ProductConverter.php
@@ -60,12 +60,13 @@ class ProductConverter extends ShopwareConverter
         /**
          * Gets the product uuid out of the mapping table or creates a new one
          */
-        $converted['id'] = $this->mappingService->getOrCreateMapping(
+        $mapping = $this->mappingService->getOrCreateMapping(
             $migrationContext->getConnection()->getId(),
             ProductDataSet::getEntity(),
             $data['id'],
             $context
         );
+        $converted['id'] = $mapping['entityUuid'];
 
         $this->convertValue($converted, 'productNumber', $data, 'product_number');
         $this->convertValue($converted, 'name', $data, 'product_name');
@@ -105,12 +106,13 @@ class ProductConverter extends ShopwareConverter
          * If no tax rate is found, create a new one
          */
         if (empty($taxUuid)) {
-            $taxUuid = $this->mappingService->getOrCreateMapping(
+            $mapping = $this->mappingService->getOrCreateMapping(
                 $this->connectionId,
                 DefaultEntities::TAX,
                 $data['id'],
                 $this->context
             );
+            $converted['id'] = $mapping['entityUuid'];
         }
 
         return [


### PR DESCRIPTION
When testing this plugin on EA2 I got the following errors:

1. private method for $mappingService should be protected
2. The method "createNewUuid" no longer exists. It has been replaced with "getOrCreateMapping"